### PR TITLE
Make it run on Windows

### DIFF
--- a/camunda.js
+++ b/camunda.js
@@ -11,7 +11,7 @@ const mkdirp = require('mkdirp');
 
 const del = require('del');
 
-let _os, CAMUNDA_VERSION = '7.8';
+const CAMUNDA_VERSION = process.argv[3] || '7.8';
 
 const TMP_DIR = path.join(__dirname + '/tmp');
 
@@ -36,27 +36,27 @@ function downloadCamunda(camundaDir) {
 }
 
 async function runCamunda(camundaDir, workDir, script) {
-    let tomcatFolder = fs.readdirSync(camundaDir + '/server')[0]; //find tomcat server folder - changes with every camunda version
+  let tomcatFolder = fs.readdirSync(camundaDir + '/server')[0]; // find tomcat server folder - changes with every camunda version
 
-    if(_os === 'windows'){
-        let env = Object.create(process.env);
-        let cwd = path.join(camundaDir.replace(/\\/g, '/'), `server/${tomcatFolder}/bin`);
+  if (process.platform === 'win32') {
+    let env = Object.create(process.env);
+    let cwd = path.join(camundaDir.replace(/\\/g, '/'), `server/${tomcatFolder}/bin`);
 
-        spawn(`${cwd}/${script}.bat`,
-            [],
-            {
-                env,
-                cwd,
-                shell: true
-            }
-        );
-    }
-    else{
-        let executable = path.join(camundaDir, `server/${tomcatFolder}/bin/${script}.sh`);
-        await execa(executable, {
-            cwd: workDir
-        });
-    }
+    spawn(`${cwd}/${script}.bat`,
+      [],
+      {
+        env,
+        cwd,
+        shell: true
+      }
+    );
+  }
+  else {
+    let executable = path.join(camundaDir, `server/${tomcatFolder}/bin/${script}.sh`);
+    await execa(executable, {
+      cwd: workDir
+    });
+  }
 }
 
 function waitUntil(fn, msg, maxWait) {
@@ -162,13 +162,3 @@ async function stopCamunda() {
 }
 
 module.exports.stopCamunda = stopCamunda;
-
-function init(os, version){
-    _os = os || 'linux';
-    CAMUNDA_VERSION = version || '7.8';
-    return {
-        startCamunda, stopCamunda
-    };
-}
-
-module.exports.init = init;

--- a/camunda.js
+++ b/camunda.js
@@ -40,7 +40,7 @@ async function runCamunda(camundaDir, workDir, script) {
 
   if (process.platform === 'win32') {
     let env = Object.create(process.env);
-    let cwd = path.join(camundaDir.replace(/\\/g, '/'), `server/${tomcatFolder}/bin`);
+    let cwd = path.join(camundaDir, `server/${tomcatFolder}/bin`);
 
     spawn(`${cwd}/${script}.bat`,
       [],

--- a/cli.js
+++ b/cli.js
@@ -3,10 +3,12 @@
 const {
   startCamunda,
   stopCamunda
-} = require('./camunda');
-
+} = require('./camunda').init(os, version);
 
 var argv = process.argv;
+var mode = argv[2];
+var os   = argv[3] || 'linux';
+var version = argv[4] || '7.8';
 
 var mode = argv[argv.length - 1];
 

--- a/cli.js
+++ b/cli.js
@@ -3,14 +3,10 @@
 const {
   startCamunda,
   stopCamunda
-} = require('./camunda').init(os, version);
+} = require('./camunda');
 
 var argv = process.argv;
 var mode = argv[2];
-var os   = argv[3] || 'linux';
-var version = argv[4] || '7.8';
-
-var mode = argv[argv.length - 1];
 
 if (mode !== 'start' && mode !== 'stop') {
   console.error('Usage: camunda [start|stop]');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "run-camunda",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "run-camunda",
-  "version": "1.2.3",
+  "version": "1.2.2",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
The package was designed to work with Linux, so I changed a few lines to make Camunda start on my Windows machine.

- Detects OS and use spawn() to start a Windows shell running Camunda
- Introduced a new test parameter to specify Camunda Version to test with (hardcoded 7.8 was to old)

Test is running fine on my Windows machine.